### PR TITLE
Update the API end point

### DIFF
--- a/o365/Office365Service.php
+++ b/o365/Office365Service.php
@@ -10,7 +10,7 @@
     private static $authorizeUrl = '/common/oauth2/authorize?client_id=%1$s&redirect_uri=%2$s&response_type=code';
     private static $tokenUrl = "/common/oauth2/token";
     private static $logoutUrl = '/common/oauth2/logout?post_logout_redirect_uri=%1$s';
-    private static $outlookApiUrl = "https://outlook.office365.com/api/v1.0";
+    private static $outlookApiUrl = "https://outlook.office.com/api/v1.0";
     
     // Set this to true to enable Fiddler capture.
     // Note that if you have this set to true and you are not running Fiddler


### PR DESCRIPTION
The previous endpoints were not working when trying to grab the events of a calendar. That worked after I changed the end point as provided by the reference docs. Rest of API works as it used with the new end point.